### PR TITLE
fix: use signal value instead of signal when loading Syndications

### DIFF
--- a/src/popup/components/form/SyndicateInputs.jsx
+++ b/src/popup/components/form/SyndicateInputs.jsx
@@ -24,7 +24,9 @@ export default function SyndicateInputs({
       {options.map((option) => (
         <Option
           option={option}
-          isChecked={selected ? selected.indexOf(option.uid) > -1 : false}
+          isChecked={
+            selected.value ? selected.value.indexOf(option.uid) > -1 : false
+          }
           isDisabled={isDisabled}
           onToggle={toggle}
         />


### PR DESCRIPTION
This fixes loading the syndication targets from the selected Signal.